### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 dateparser
+glob2
+logging


### PR DESCRIPTION
The modules glob2 and logging are required for this extension to work, but they're not installed by default for people who have just installed core Python.