### PR TITLE
Use origin python

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 """Ulauncher extension main class """
 
+import sys
 import os
 import logging
 import subprocess
@@ -110,8 +111,7 @@ class ItemEnterEventListener(EventListener):
     """ Handles item enter """
     def on_event(self, event, extension):
         data = event.get_data()
-
-        cmd = "python %s %s " % (PLACEHOLDER_SCRIPTS_PATH, data['path'])
+        cmd = f"{sys.executable} {PLACEHOLDER_SCRIPTS_PATH} {data['path']} "
 
         process = subprocess.Popen(cmd,
                                    shell=True,


### PR DESCRIPTION
Not all OS use `python` as a link for `python3`.
For example, Ubuntu 18.04 is still using `python2` as the target for `python` link.

This change makes call python which is used for `ulauncher` call.